### PR TITLE
Fix return type in truncate_index()

### DIFF
--- a/lib/Cache.php
+++ b/lib/Cache.php
@@ -261,9 +261,9 @@ class Cache
    * Prefers to eject the smallest cache content first
    *
    * @param  string $collection
-   * @return bool
+   * @return void
    */
-  public function truncate_index($collection): bool
+  public function truncate_index($collection)
   {
     $this->get_index();
     asort($this->indexes[$collection]);
@@ -271,7 +271,7 @@ class Cache
     $key = key($this->indexes[$collection]);
 
     $invalid = ["{$collection}" => $key];
-    return $this->clear_indexes($invalid);
+    $this->clear_indexes($invalid);
   }
 
   /**


### PR DESCRIPTION
https://app.asana.com/0/1202306318068147/1204960655160307/f

## Description
Images are broken in swell-hosted storefront.

`truncate_index()` return type is updated wrongly as bool instead of void. It causes the caching fails and images are throwing 500 error.

**Error reference:**
App Exception: Return value of Swell\\Cache::truncate_index() must be of the type bool, null returned in /schema/app/core/lib/schema-php-client/lib/Cache.php on line 274 (code: 0)