### PR TITLE
feat: add default value for verify_peer_name param

### DIFF
--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -86,10 +86,12 @@ class Connection
       $options = [
         "ssl" => [
           "verify_peer" => false,
+          "verify_peer_name" => false
         ],
       ];
       if ($this->options["verify_cert"]) {
         $options["ssl"]["verify_peer"] = true;
+        $options["ssl"]["verify_peer_name"] = true;
         $options["ssl"]["verify_depth"] = 5;
         $options["ssl"]["cafile"] =
           \dirname(\dirname(__FILE__)) . "/data/ca-certificates.crt";


### PR DESCRIPTION
### Description

- Added default value for verify_peer_name param

It would be helpful for using on review-apps, where host name differs from `api.swell.store`